### PR TITLE
remove min_const_generics flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(min_const_generics)]
 pub mod utils;
 mod tree_structure;
 mod cell;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(min_const_generics)]
 extern crate appr_dbscan;
 use appr_dbscan::do_appr_dbscan_auto_dimensionality_file;
 use appr_dbscan::data_io::{params_from_file, write_to_bmp_vec};


### PR DESCRIPTION
`#![feature(min_const_generics)]` does not compile anymore so it is removed.